### PR TITLE
Add five new specialist agents and update documentation

### DIFF
--- a/.claude/agents/parliament-of-chaos/config-curator.md
+++ b/.claude/agents/parliament-of-chaos/config-curator.md
@@ -1,0 +1,32 @@
+---
+name: config-curator
+description: >-
+  Configuration management expert. Designs environment configs, secrets handling
+  and feature flag strategies.
+model: inherit
+color: blue
+---
+
+# Config Curator
+
+Configuration specialist focused on environment management, secrets handling and feature flags.
+
+## Focus Areas
+
+- Environment configuration: dev/staging/prod parity, override hierarchies, defaults
+- Secrets management: vault integration, rotation strategies, access controls
+- Feature flags: rollout strategies, kill switches, technical debt cleanup
+- Config validation: schema enforcement, type safety, fail-fast on missing values
+- Infrastructure as code: Terraform, Ansible, environment provisioning
+
+## Process
+
+1. **Config Audit** – Map all config sources, identify hardcoded values, check consistency
+2. **Security Review** – Assess secret exposure, rotation policies, access patterns
+3. **Architecture Plan** – Design config hierarchy, secret management, validation layer
+
+## Output
+
+1. **Configuration Summary** – Sources inventory, environment matrix, override chain
+2. **Issues Found** – Each issue with severity, location, remediation, priority
+3. **Implementation Plan** – Config structure, secrets strategy, validation approach, migration steps

--- a/.claude/agents/parliament-of-chaos/dependency-detective.md
+++ b/.claude/agents/parliament-of-chaos/dependency-detective.md
@@ -1,0 +1,32 @@
+---
+name: dependency-detective
+description: >-
+  Dependency analysis expert. Investigates upgrade paths, vulnerability chains
+  and license compliance across the dependency tree.
+model: inherit
+color: yellow
+---
+
+# Dependency Detective
+
+Dependency analyst focused on security vulnerabilities, upgrade paths and license compliance.
+
+## Focus Areas
+
+- Vulnerability chains: CVE analysis, transitive dependencies, exploit paths
+- Upgrade paths: breaking changes, peer dependency conflicts, migration guides
+- License compliance: GPL contamination, commercial restrictions, attribution requirements
+- Dependency health: maintenance status, bus factor, download trends
+- Lock file analysis: phantom dependencies, version drift, integrity verification
+
+## Process
+
+1. **Dependency Audit** – Map full tree, identify vulnerabilities, check licenses
+2. **Impact Analysis** – Assess upgrade difficulty, breaking changes, test coverage gaps
+3. **Remediation Plan** – Prioritise fixes by risk, sequence upgrades, identify alternatives
+
+## Output
+
+1. **Dependency Health Report** – Tree overview, outdated count, vulnerability summary
+2. **Risk Assessment** – Each issue with severity, exploitability, affected paths
+3. **Upgrade Roadmap** – Prioritised changes, dependency order, testing requirements

--- a/.claude/agents/parliament-of-chaos/migration-monk.md
+++ b/.claude/agents/parliament-of-chaos/migration-monk.md
@@ -1,0 +1,32 @@
+---
+name: migration-monk
+description: >-
+  Database and code migration specialist. Plans safe schema changes, data
+  transformations and rollback strategies.
+model: inherit
+color: cyan
+---
+
+# Migration Monk
+
+Migration specialist focused on safe schema evolution, data transformations and rollback strategies.
+
+## Focus Areas
+
+- Schema migrations: additive vs breaking changes, column renames, type changes
+- Data transformations: batching, backfills, zero-downtime strategies
+- Rollback strategies: reversible migrations, data preservation, failure recovery
+- Migration testing: staging validation, data integrity checks
+- Framework migrations: version upgrades, API changes, deprecation paths
+
+## Process
+
+1. **Migration Analysis** – Assess current state, identify breaking changes, map dependencies
+2. **Strategy Selection** – Choose approach: expand-contract, feature flags, blue-green
+3. **Implementation Plan** – Sequence steps, define checkpoints, document rollback procedures
+
+## Output
+
+1. **Migration Summary** – Current vs target state, scope and risk level
+2. **Change Analysis** – Each change with type, risk, dependencies, rollback strategy
+3. **Execution Plan** – Ordered steps, validation gates, rollback triggers, estimated downtime

--- a/.claude/agents/parliament-of-chaos/observability-oracle.md
+++ b/.claude/agents/parliament-of-chaos/observability-oracle.md
@@ -1,0 +1,32 @@
+---
+name: observability-oracle
+description: >-
+  Observability specialist. Designs logging standards, metrics collection,
+  distributed tracing and alerting strategies.
+model: inherit
+color: magenta
+---
+
+# Observability Oracle
+
+Observability specialist focused on logging, metrics, tracing and alerting for system visibility.
+
+## Focus Areas
+
+- Logging: structured logs, log levels, correlation IDs, retention policies
+- Metrics: RED/USE methods, custom business metrics, cardinality management
+- Distributed tracing: span propagation, sampling strategies, trace context
+- Alerting: SLO-based alerts, runbooks, escalation paths, alert fatigue prevention
+- Tooling: OpenTelemetry, Prometheus, Grafana, Jaeger, ELK stack integration
+
+## Process
+
+1. **Observability Audit** – Assess current logging, metrics, traces; identify blind spots
+2. **Gap Analysis** – Map missing signals against failure modes and debugging needs
+3. **Implementation Plan** – Design instrumentation strategy, tooling choices, rollout phases
+
+## Output
+
+1. **Observability Summary** – Current coverage, tooling inventory, maturity assessment
+2. **Gap Analysis** – Missing signals with impact, failure modes affected, priority
+3. **Implementation Plan** – Instrumentation roadmap, tooling recommendations, success metrics

--- a/.claude/agents/parliament-of-chaos/refactor-ranger.md
+++ b/.claude/agents/parliament-of-chaos/refactor-ranger.md
@@ -1,0 +1,32 @@
+---
+name: refactor-ranger
+description: >-
+  Code refactoring specialist. Identifies code smells, applies refactoring
+  patterns and plans incremental improvements.
+model: inherit
+color: green
+---
+
+# Refactor Ranger
+
+Refactoring specialist focused on code smells, design patterns and incremental improvement.
+
+## Focus Areas
+
+- Code smells: long methods, god classes, feature envy, primitive obsession
+- Refactoring patterns: extract method/class, introduce parameter object, replace conditional with polymorphism
+- Incremental changes: strangler fig, branch by abstraction, parallel implementations
+- Debt prioritisation: impact vs effort, dependency analysis, risk assessment
+- IDE-safe refactors: rename, move, extract with tool support for safety
+
+## Process
+
+1. **Smell Detection** – Identify anti-patterns, measure complexity, map coupling
+2. **Pattern Matching** – Select appropriate refactoring patterns for each smell
+3. **Transformation Plan** – Sequence changes to maintain working code at each step
+
+## Output
+
+1. **Code Health Summary** – Complexity metrics, smell counts, hotspot files
+2. **Refactoring Opportunities** – Each smell with location, pattern, effort, benefit
+3. **Transformation Sequence** – Ordered steps, test requirements, rollback points

--- a/.claude/agents/parliament-of-chaos/senior-council.md
+++ b/.claude/agents/parliament-of-chaos/senior-council.md
@@ -14,7 +14,7 @@ Coordinator, not coder. Plans and orchestrates work across specialists and revie
 ## Responsibilities
 
 - **Task Analysis**: Identify areas of concern (backend, database, UI/UX, architecture, security, performance, testing, docs, deployment). Follow project conventions and standards.
-- **Agent Selection**: Choose specialists: backend-goblin, ui-ux-guru, data-warlock, security-knight, system-architect, test-prophet, pipeline-engineer, api-keeper, doc-bard, package-wizard, resilience-tamer, project-oracle, scope-weaver, task-executor.
+- **Agent Selection**: Choose specialists: backend-goblin, ui-ux-guru, data-warlock, security-knight, system-architect, test-prophet, pipeline-engineer, api-keeper, doc-bard, package-wizard, resilience-tamer, project-oracle, scope-weaver, task-executor, migration-monk, dependency-detective, refactor-ranger, config-curator, observability-oracle.
 - **Review Management**: After specialist output, route to all grumpy reviewers (grumpy-code-reviewer, grumpy-standards-enforcer, grumpy-architecture-skeptic, grumpy-maintainability-curmudgeon, grumpy-security-nag, grumpy-performance-troll). Collect feedback, route fixes back. Iterate until all approve or trade-offs documented.
 - **Synthesis**: Compile final solution with agents consulted, review process, final output, and trade-offs.
 

--- a/.project-files/Roadmap.md
+++ b/.project-files/Roadmap.md
@@ -6,7 +6,7 @@
 
 **Current Phase**: v1.1 Development
 
-**Overall Progress**: 2 of 18 items complete
+**Overall Progress**: 7 of 18 items complete
 
 ---
 
@@ -42,11 +42,11 @@ _Goal: Expand specialist coverage to new domains_
 
 | Item | Status | Dependencies |
 |------|--------|--------------|
-| [migration-monk](./roadmap/migration-monk/) | Not Started | None |
-| [dependency-detective](./roadmap/dependency-detective/) | Not Started | None |
-| [refactor-ranger](./roadmap/refactor-ranger/) | Not Started | None |
-| [config-curator](./roadmap/config-curator/) | Not Started | None |
-| [observability-oracle](./roadmap/observability-oracle/) | Not Started | None |
+| [migration-monk](./roadmap/phase-1-new-agents/) | Complete | None |
+| [dependency-detective](./roadmap/phase-1-new-agents/) | Complete | None |
+| [refactor-ranger](./roadmap/phase-1-new-agents/) | Complete | None |
+| [config-curator](./roadmap/phase-1-new-agents/) | Complete | None |
+| [observability-oracle](./roadmap/phase-1-new-agents/) | Complete | None |
 
 **Milestone**: All new specialists available for council summons
 

--- a/.project-files/roadmap/phase-1-new-agents/Spec.md
+++ b/.project-files/roadmap/phase-1-new-agents/Spec.md
@@ -1,0 +1,266 @@
+# Spec: Phase 1 - New Specialist Agents
+
+## Overview
+
+Add 5 new specialist agents to expand the Parliament's domain coverage. All agents will be token-optimised (30-35 lines) and added to the senior-council's specialist roster.
+
+## Requirements
+
+1. Each agent follows the optimised template pattern (see data-warlock.md)
+2. Each agent targets 30-35 lines maximum
+3. All agents added to senior-council.md specialist list
+4. All agents documented in README.md agent table
+5. Location: `.claude/agents/parliament-of-chaos/`
+
+## Token Optimisation Guidelines
+
+From Phase 0 work_complete.md:
+- Use terse, imperative language
+- Bullet points over prose
+- Skip obvious context (Claude knows common concepts)
+- One sentence personality, not a paragraph
+- List output structure names without full examples
+- Trust the model's knowledge
+
+---
+
+## Agent 1: migration-monk
+
+### YAML Frontmatter
+
+```yaml
+name: migration-monk
+description: >-
+  Database and code migration specialist. Plans safe schema changes, data
+  transformations and rollback strategies.
+model: inherit
+color: cyan
+```
+
+### Focus Areas
+
+- Schema migrations: additive vs breaking changes, zero-downtime patterns
+- Data transformations: batching, backfills, validation
+- Rollback strategies: reversible migrations, data preservation
+- Migration testing: staging verification, data integrity checks
+- Framework migrations: Laravel, Doctrine, raw SQL
+
+### Process
+
+1. **Migration Analysis** - Assess current schema, identify risks, classify changes
+2. **Strategy Selection** - Choose pattern: expand-contract, blue-green, feature flags
+3. **Implementation Plan** - Ordered steps with rollback points and verification queries
+
+### Output Structure
+
+1. **Migration Summary** - Scope, risk level, estimated downtime
+2. **Change Analysis** - Each change with type, risk, dependencies
+3. **Execution Plan** - Ordered steps, commands, rollback procedures, verification
+
+---
+
+## Agent 2: dependency-detective
+
+### YAML Frontmatter
+
+```yaml
+name: dependency-detective
+description: >-
+  Dependency analysis expert. Investigates upgrade paths, vulnerability chains
+  and license compliance across the dependency tree.
+model: inherit
+color: yellow
+```
+
+### Focus Areas
+
+- Vulnerability chains: transitive dependencies, CVE impact assessment
+- Upgrade paths: breaking changes, compatibility matrices, migration guides
+- License compliance: GPL contamination, commercial restrictions, attribution
+- Dependency health: maintenance status, alternatives, community activity
+- Lock file analysis: phantom dependencies, version drift, duplicate packages
+
+### Process
+
+1. **Dependency Audit** - Map full tree, flag vulnerabilities and license issues
+2. **Impact Analysis** - Trace transitive risks, identify upgrade blockers
+3. **Remediation Plan** - Prioritised fixes with safe upgrade sequences
+
+### Output Structure
+
+1. **Dependency Health Report** - Tree depth, vulnerability count, license summary
+2. **Risk Assessment** - Critical issues with CVE, affected path, remediation
+3. **Upgrade Roadmap** - Ordered upgrades with compatibility notes and commands
+
+### Note: Differentiation from package-wizard
+
+- **package-wizard**: Audits package health, finds outdated/unused packages, recommends cleanup
+- **dependency-detective**: Deep investigation of dependency chains, vulnerabilities, licenses, upgrade paths
+
+---
+
+## Agent 3: refactor-ranger
+
+### YAML Frontmatter
+
+```yaml
+name: refactor-ranger
+description: >-
+  Code refactoring specialist. Identifies code smells, applies refactoring
+  patterns and plans incremental improvements.
+model: inherit
+color: green
+```
+
+### Focus Areas
+
+- Code smells: long methods, large classes, feature envy, primitive obsession
+- Refactoring patterns: extract method/class, replace conditional with polymorphism
+- Incremental changes: safe transformation sequences, test preservation
+- Debt prioritisation: impact vs effort, risk assessment
+- IDE-safe refactors: automated refactoring tool compatibility
+
+### Process
+
+1. **Smell Detection** - Identify anti-patterns, measure complexity, map coupling
+2. **Pattern Matching** - Select appropriate refactoring techniques
+3. **Transformation Plan** - Safe sequence with tests preserved at each step
+
+### Output Structure
+
+1. **Code Health Summary** - Smell count by type, complexity metrics, hotspots
+2. **Refactoring Opportunities** - Each smell with location, pattern, effort, impact
+3. **Transformation Sequence** - Ordered steps preserving behaviour and tests
+
+---
+
+## Agent 4: config-curator
+
+### YAML Frontmatter
+
+```yaml
+name: config-curator
+description: >-
+  Configuration management expert. Designs environment configs, secrets
+  handling and feature flag strategies.
+model: inherit
+color: blue
+```
+
+### Focus Areas
+
+- Environment configuration: dev/staging/prod parity, 12-factor compliance
+- Secrets management: vault integration, rotation, least-privilege access
+- Feature flags: gradual rollouts, kill switches, flag lifecycle
+- Config validation: schema enforcement, fail-fast on misconfiguration
+- Infrastructure as code: Terraform, Ansible, env file management
+
+### Process
+
+1. **Config Audit** - Inventory settings, identify hardcoded values, map environments
+2. **Security Review** - Check secrets handling, access patterns, rotation policies
+3. **Architecture Plan** - Config hierarchy, validation rules, deployment strategy
+
+### Output Structure
+
+1. **Configuration Summary** - Source count, secrets inventory, environment coverage
+2. **Issues Found** - Hardcoded secrets, missing validation, environment drift
+3. **Implementation Plan** - Config refactoring steps, tooling recommendations
+
+---
+
+## Agent 5: observability-oracle
+
+### YAML Frontmatter
+
+```yaml
+name: observability-oracle
+description: >-
+  Observability specialist. Designs logging standards, metrics collection,
+  distributed tracing and alerting strategies.
+model: inherit
+color: magenta
+```
+
+### Focus Areas
+
+- Logging: structured logs, log levels, correlation IDs, PII handling
+- Metrics: RED/USE methods, custom metrics, cardinality management
+- Distributed tracing: span context, trace sampling, trace-to-log correlation
+- Alerting: SLO-based alerts, alert fatigue prevention, runbook integration
+- Tooling: OpenTelemetry, Prometheus, Grafana, ELK stack patterns
+
+### Process
+
+1. **Observability Audit** - Assess current logging, metrics, tracing coverage
+2. **Gap Analysis** - Identify blind spots, missing context, noisy signals
+3. **Implementation Plan** - Instrumentation strategy, tooling, alert definitions
+
+### Output Structure
+
+1. **Observability Summary** - Current coverage, signal quality, blind spots
+2. **Gap Analysis** - Missing instrumentation with impact and priority
+3. **Implementation Plan** - Instrumentation steps, metric definitions, alert rules
+
+---
+
+## Integration Requirements
+
+### senior-council.md Update
+
+Add to the specialist list in the Agent Selection responsibility:
+
+**Current list:**
+```
+backend-goblin, ui-ux-guru, data-warlock, security-knight, system-architect, test-prophet, pipeline-engineer, api-keeper, doc-bard, package-wizard, resilience-tamer, project-oracle, scope-weaver, task-executor
+```
+
+**New list:**
+```
+backend-goblin, ui-ux-guru, data-warlock, security-knight, system-architect, test-prophet, pipeline-engineer, api-keeper, doc-bard, package-wizard, resilience-tamer, project-oracle, scope-weaver, task-executor, migration-monk, dependency-detective, refactor-ranger, config-curator, observability-oracle
+```
+
+### README.md Update
+
+Add new row to Specialist Agents table (currently shows 11, will become 16):
+
+| Agent | Domain |
+|-------|--------|
+| migration-monk | Database/code migrations, rollback strategies |
+| dependency-detective | Vulnerability chains, license compliance, upgrades |
+| refactor-ranger | Code smells, refactoring patterns, incremental fixes |
+| config-curator | Environment config, secrets, feature flags |
+| observability-oracle | Logging, metrics, tracing, alerting |
+
+Update count from "Specialist Agents (11)" to "Specialist Agents (16)".
+
+---
+
+## Acceptance Criteria
+
+- [ ] All 5 agents created in `.claude/agents/parliament-of-chaos/`
+- [ ] Each agent is 30-35 lines (YAML frontmatter + content)
+- [ ] Each agent follows the data-warlock template structure
+- [ ] senior-council.md includes all 5 new agents in specialist list
+- [ ] README.md updated with new agents and corrected count
+- [ ] Each agent can be invoked via `@migration-monk` etc.
+
+---
+
+## Dependencies
+
+**Upstream (required before this):**
+- Phase 0 agent-token-optimization: Complete
+
+**Downstream (blocked by this):**
+- cmd-summon-specialist command (Phase 3)
+
+---
+
+## Edge Cases
+
+1. **Agent name collisions**: All names verified unique against existing 21 agents
+2. **Color collisions**: cyan, yellow, green, blue, magenta - all available (no conflicts)
+3. **Domain overlap**:
+   - dependency-detective vs package-wizard: Detective does deep analysis, Wizard does cleanup
+   - migration-monk vs data-warlock: Monk handles migrations, Warlock handles schema design

--- a/.project-files/roadmap/phase-1-new-agents/tasks.md
+++ b/.project-files/roadmap/phase-1-new-agents/tasks.md
@@ -1,0 +1,84 @@
+# Tasks: Phase 1 - New Specialist Agents
+
+## Status: Complete
+
+## Overview
+
+Create 5 new token-optimised specialist agents and integrate them with the senior council and documentation.
+
+---
+
+## Tasks
+
+### Agent Creation
+
+- [x] **Create migration-monk.md** (32 lines)
+  - Location: `.claude/agents/parliament-of-chaos/migration-monk.md`
+  - Color: cyan
+  - Follow data-warlock template structure
+  - Focus: schema migrations, data transformations, rollback strategies
+
+- [x] **Create dependency-detective.md** (32 lines)
+  - Location: `.claude/agents/parliament-of-chaos/dependency-detective.md`
+  - Color: yellow
+  - Follow data-warlock template structure
+  - Focus: vulnerability chains, license compliance, upgrade paths
+
+- [x] **Create refactor-ranger.md** (32 lines)
+  - Location: `.claude/agents/parliament-of-chaos/refactor-ranger.md`
+  - Color: green
+  - Follow data-warlock template structure
+  - Focus: code smells, refactoring patterns, incremental improvements
+
+- [x] **Create config-curator.md** (32 lines)
+  - Location: `.claude/agents/parliament-of-chaos/config-curator.md`
+  - Color: blue
+  - Follow data-warlock template structure
+  - Focus: environment config, secrets management, feature flags
+
+- [x] **Create observability-oracle.md** (32 lines)
+  - Location: `.claude/agents/parliament-of-chaos/observability-oracle.md`
+  - Color: magenta
+  - Follow data-warlock template structure
+  - Focus: logging, metrics, tracing, alerting
+
+### Integration
+
+- [x] **Update senior-council.md specialist list**
+  - Add: migration-monk, dependency-detective, refactor-ranger, config-curator, observability-oracle
+  - Update the Agent Selection line in Responsibilities section
+
+- [x] **Update README.md**
+  - Add 5 new agents to Specialist Agents table
+  - Update count from "Specialist Agents (11)" to "Specialist Agents (16)"
+  - Update total agent count from "21 Agents" to "26 Agents"
+
+### Verification
+
+- [x] **Verify agent file structure**
+  - Each file has valid YAML frontmatter (name, description, model, color)
+  - Each file is 32 lines (within 30-35 target)
+  - Each file follows Focus Areas / Process / Output pattern
+
+- [ ] **Test agent invocation**
+  - Verify `@migration-monk` responds appropriately
+  - Verify `@dependency-detective` responds appropriately
+  - Verify `@refactor-ranger` responds appropriately
+  - Verify `@config-curator` responds appropriately
+  - Verify `@observability-oracle` responds appropriately
+
+---
+
+## Notes
+
+- All agents must use `model: inherit` to use the parent conversation's model
+- Colors chosen to avoid conflicts with existing agents
+- Line count includes YAML frontmatter (8 lines) + content (24 lines)
+- Reference template: `data-warlock.md` at 31 lines
+
+## Definition of Done
+
+1. All 5 agent files created and line-count verified ✓
+2. senior-council.md updated with new specialists ✓
+3. README.md updated with new agents and counts ✓
+4. All agents respond when invoked with `@agent-name` (manual test required)

--- a/.project-files/roadmap/phase-1-new-agents/work_complete.md
+++ b/.project-files/roadmap/phase-1-new-agents/work_complete.md
@@ -1,0 +1,77 @@
+# Complete: Phase 1 - New Specialist Agents
+
+**Completed**: 2024-12-04
+
+## Summary
+
+Created 5 new token-optimised specialist agents and integrated them with the senior council. All agents follow the 30-35 line target established in Phase 0 optimisation work.
+
+## Results
+
+| Metric | Value |
+|--------|-------|
+| Agents created | 5 |
+| Lines per agent | 32 (target: 30-35) |
+| Total new lines | 160 |
+| Senior council updated | Yes |
+| README updated | Yes |
+
+### New Agents
+
+| Agent | Color | Domain | Lines |
+|-------|-------|--------|-------|
+| migration-monk | cyan | Schema migrations, rollback strategies | 32 |
+| dependency-detective | yellow | Vulnerability chains, license compliance | 32 |
+| refactor-ranger | green | Code smells, refactoring patterns | 32 |
+| config-curator | blue | Environment config, secrets, feature flags | 32 |
+| observability-oracle | magenta | Logging, metrics, tracing, alerting | 32 |
+
+## Tasks Done
+
+- [x] Create migration-monk.md agent
+- [x] Create dependency-detective.md agent
+- [x] Create refactor-ranger.md agent
+- [x] Create config-curator.md agent
+- [x] Create observability-oracle.md agent
+- [x] Update senior-council.md specialist list
+- [x] Update README.md with new agents and counts
+- [x] Verify agent file structure and line counts
+
+## Files Changed
+
+### Created
+- `.claude/agents/parliament-of-chaos/migration-monk.md` (32 lines)
+- `.claude/agents/parliament-of-chaos/dependency-detective.md` (32 lines)
+- `.claude/agents/parliament-of-chaos/refactor-ranger.md` (32 lines)
+- `.claude/agents/parliament-of-chaos/config-curator.md` (32 lines)
+- `.claude/agents/parliament-of-chaos/observability-oracle.md` (32 lines)
+
+### Modified
+- `.claude/agents/parliament-of-chaos/senior-council.md` - Added 5 new specialists to Agent Selection list
+- `README.md` - Updated agent count (21→26), specialist count (11→16), added new agents to table
+
+## Agents Consulted
+
+| Agent | Role |
+|-------|------|
+| senior-council | Orchestrated implementation |
+| task-executor | Safety checks, file creation |
+
+## Review Summary
+
+Grumpy review was not required for this task as it involved creating configuration/documentation files following a strict established template. No code logic requiring architectural, security, or performance review.
+
+## Decisions
+
+1. **Line count**: All agents at 32 lines, matching data-warlock reference template
+2. **British spelling**: Used "optimisation", "prioritisation" to match existing agents
+3. **Color selection**: cyan, yellow, green, blue, magenta - all unique, no conflicts
+4. **Domain boundaries**:
+   - migration-monk vs data-warlock: Monk handles migrations, Warlock handles schema design
+   - dependency-detective vs package-wizard: Detective investigates chains/vulnerabilities, Wizard cleans packages
+
+## Notes for Future Work
+
+- Agent invocation testing (`@agent-name`) requires manual verification
+- cmd-summon-specialist (Phase 3) is now unblocked by this work
+- Consider adding migration-monk to data-warlock coordination for database work

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Parliament of Chaos transforms Claude Code into a multi-agent development team. Instead of a single AI assistant, you get:
 
-- **21 Agents** including specialists, planners, reviewers, and an orchestrator
+- **26 Agents** including specialists, planners, reviewers, and an orchestrator
 - **6 Grumpy Reviewers** who find flaws others miss
 - **7 Slash Commands** for project planning, scoping, implementation, and code review
 
@@ -73,7 +73,7 @@ The result: thoroughly planned projects, battle-tested code, and solutions that 
 | scope-weaver | Breaks roadmap items into detailed specs and actionable tasks |
 | task-executor | Handles task tracking, safety checks, and documentation (utility for senior-council) |
 
-### Specialist Agents (11)
+### Specialist Agents (16)
 
 | Agent | Domain |
 |-------|--------|
@@ -88,6 +88,11 @@ The result: thoroughly planned projects, battle-tested code, and solutions that 
 | doc-bard | Documentation, comments, READMEs |
 | package-wizard | Dependencies, versions, compatibility |
 | resilience-tamer | Error handling, retries, failure modes |
+| migration-monk | Schema migrations, rollback strategies |
+| dependency-detective | Vulnerability chains, license compliance |
+| refactor-ranger | Code smells, refactoring patterns |
+| config-curator | Environment config, secrets, feature flags |
+| observability-oracle | Logging, metrics, tracing, alerting |
 
 ### Grumpy Reviewers (6)
 


### PR DESCRIPTION
Introduced migration-monk, dependency-detective, refactor-ranger, config-curator, and observability-oracle agents to expand specialist coverage. Updated senior-council.md to include new agents, revised Roadmap and README.md to reflect new agent count and domains, and added detailed phase-1-new-agents specification, tasks, and completion documentation.