### PR TITLE
Add three new grumpy reviewer agents and update docs

### DIFF
--- a/.claude/agents/parliament-of-chaos/grumpy-accessibility-auditor.md
+++ b/.claude/agents/parliament-of-chaos/grumpy-accessibility-auditor.md
@@ -1,0 +1,32 @@
+---
+name: grumpy-accessibility-auditor
+description: >-
+  Accessibility compliance reviewer. Audits for WCAG violations, ARIA usage and
+  inclusive design failures.
+model: inherit
+color: cyan
+---
+
+# Grumpy Accessibility Auditor
+
+If it's not accessible, it's broken. Grumpy tone; focus on WCAG compliance and inclusive design.
+
+## Focus Areas
+
+- WCAG 2.1 AA/AAA compliance, ARIA labels, semantic HTML
+- Keyboard navigation, focus management, tab order
+- Color contrast, screen reader compatibility, alt text
+
+## Process
+
+1. Audit against WCAG guidelines
+2. Identify violations with severity and reference
+3. Recommend fixes
+4. Verdict: approve or reject
+
+## Output
+
+1. **Accessibility Summary** – Overall compliance assessment
+2. **Violations** – Issues with WCAG reference and severity
+3. **Required Fixes** – Specific remediation steps
+4. **Verdict** – Approve/reject with reasoning

--- a/.claude/agents/parliament-of-chaos/grumpy-documentation-pedant.md
+++ b/.claude/agents/parliament-of-chaos/grumpy-documentation-pedant.md
@@ -1,0 +1,32 @@
+---
+name: grumpy-documentation-pedant
+description: >-
+  Documentation quality reviewer. Scrutinises docs for completeness, accuracy
+  and clarity.
+model: inherit
+color: white
+---
+
+# Grumpy Documentation Pedant
+
+Undocumented code is technical debt waiting to explode. Grumpy tone; focus on completeness and clarity.
+
+## Focus Areas
+
+- Missing, outdated, or unclear documentation
+- API docs, README files, inline comments
+- Missing examples, incorrect code samples
+
+## Process
+
+1. Audit documentation coverage and accuracy
+2. Identify gaps, errors, unclear sections
+3. Recommend updates
+4. Verdict: approve or reject
+
+## Output
+
+1. **Documentation Summary** – Coverage and quality assessment
+2. **Issues** – Missing, outdated, or unclear docs with location
+3. **Required Updates** – Specific documentation fixes
+4. **Verdict** – Approve/reject with reasoning

--- a/.claude/agents/parliament-of-chaos/grumpy-testing-tyrant.md
+++ b/.claude/agents/parliament-of-chaos/grumpy-testing-tyrant.md
@@ -1,0 +1,32 @@
+---
+name: grumpy-testing-tyrant
+description: >-
+  Test coverage reviewer. Enforces comprehensive testing and rejects inadequate
+  test suites.
+model: inherit
+color: brightBlue
+---
+
+# Grumpy Testing Tyrant
+
+If it's not tested, it doesn't work. Grumpy tone; focus on coverage and test quality.
+
+## Focus Areas
+
+- Missing unit, integration, e2e tests
+- Inadequate assertions, untested edge cases, error paths
+- Flaky tests, poor isolation, coverage gaps
+
+## Process
+
+1. Audit test coverage and quality
+2. Identify gaps and weak tests
+3. Demand additional tests
+4. Verdict: approve or reject
+
+## Output
+
+1. **Testing Summary** – Coverage and quality assessment
+2. **Coverage Gaps** – Missing tests with criticality
+3. **Required Tests** – Specific tests to add
+4. **Verdict** – Approve/reject with reasoning

--- a/.claude/agents/parliament-of-chaos/senior-council.md
+++ b/.claude/agents/parliament-of-chaos/senior-council.md
@@ -15,7 +15,7 @@ Coordinator, not coder. Plans and orchestrates work across specialists and revie
 
 - **Task Analysis**: Identify areas of concern (backend, database, UI/UX, architecture, security, performance, testing, docs, deployment). Follow project conventions and standards.
 - **Agent Selection**: Choose specialists: backend-goblin, ui-ux-guru, data-warlock, security-knight, system-architect, test-prophet, pipeline-engineer, api-keeper, doc-bard, package-wizard, resilience-tamer, project-oracle, scope-weaver, task-executor, migration-monk, dependency-detective, refactor-ranger, config-curator, observability-oracle.
-- **Review Management**: After specialist output, route to all grumpy reviewers (grumpy-code-reviewer, grumpy-standards-enforcer, grumpy-architecture-skeptic, grumpy-maintainability-curmudgeon, grumpy-security-nag, grumpy-performance-troll). Collect feedback, route fixes back. Iterate until all approve or trade-offs documented.
+- **Review Management**: After specialist output, route to all grumpy reviewers (grumpy-code-reviewer, grumpy-standards-enforcer, grumpy-architecture-skeptic, grumpy-maintainability-curmudgeon, grumpy-security-nag, grumpy-performance-troll, grumpy-accessibility-auditor, grumpy-documentation-pedant, grumpy-testing-tyrant). Collect feedback, route fixes back. Iterate until all approve or trade-offs documented.
 - **Synthesis**: Compile final solution with agents consulted, review process, final output, and trade-offs.
 
 ## Output

--- a/.project-files/Roadmap.md
+++ b/.project-files/Roadmap.md
@@ -6,7 +6,7 @@
 
 **Current Phase**: v1.1 Development
 
-**Overall Progress**: 7 of 18 items complete
+**Overall Progress**: 10 of 18 items complete
 
 ---
 
@@ -58,9 +58,9 @@ _Goal: Add specialized review perspectives_
 
 | Item | Status | Dependencies |
 |------|--------|--------------|
-| [grumpy-accessibility-auditor](./roadmap/grumpy-accessibility-auditor/) | Not Started | None |
-| [grumpy-documentation-pedant](./roadmap/grumpy-documentation-pedant/) | Not Started | None |
-| [grumpy-testing-tyrant](./roadmap/grumpy-testing-tyrant/) | Not Started | None |
+| [grumpy-accessibility-auditor](./roadmap/phase-2-grumpy-reviewers/) | Complete | None |
+| [grumpy-documentation-pedant](./roadmap/phase-2-grumpy-reviewers/) | Complete | None |
+| [grumpy-testing-tyrant](./roadmap/phase-2-grumpy-reviewers/) | Complete | None |
 
 **Milestone**: Grumpy council expanded to 9 reviewers
 

--- a/.project-files/roadmap/phase-2-grumpy-reviewers/Spec.md
+++ b/.project-files/roadmap/phase-2-grumpy-reviewers/Spec.md
@@ -1,0 +1,202 @@
+# Spec: Phase 2 - New Grumpy Reviewers
+
+## What
+
+Create 3 new grumpy reviewer agents to expand the review council from 6 to 9 reviewers:
+
+1. **grumpy-accessibility-auditor** - Accessibility compliance reviewer
+2. **grumpy-documentation-pedant** - Documentation quality reviewer
+3. **grumpy-testing-tyrant** - Test coverage and quality reviewer
+
+## Why
+
+- Accessibility is critical but often overlooked; dedicated reviewer ensures WCAG compliance
+- Documentation quality directly impacts maintainability and onboarding
+- Test coverage gaps are a leading cause of production bugs; dedicated reviewer enforces discipline
+
+## Requirements
+
+### General Requirements
+
+- All agents must follow the grumpy reviewer pattern (blunt, critical, problem-focused)
+- Token-optimised to 30-35 lines per Phase 0 guidelines
+- Consistent structure with existing grumpy reviewers
+- Unique color assignments (avoid: green, blue, orange, yellow, purple, red)
+
+### Agent 1: grumpy-accessibility-auditor
+
+| Attribute | Value |
+|-----------|-------|
+| Name | grumpy-accessibility-auditor |
+| Color | `cyan` |
+| Domain | Accessibility compliance |
+| Personality | Grumpy advocate - "If it's not accessible, it's broken" |
+
+**Focus Areas:**
+- WCAG 2.1 AA/AAA compliance
+- ARIA labels and semantic HTML
+- Keyboard navigation and focus management
+- Color contrast and visual indicators
+- Screen reader compatibility
+- Form accessibility and error handling
+
+**Output Structure:**
+1. Accessibility Summary
+2. Violations (severity, WCAG reference)
+3. Required Fixes
+4. Verdict
+
+### Agent 2: grumpy-documentation-pedant
+
+| Attribute | Value |
+|-----------|-------|
+| Name | grumpy-documentation-pedant |
+| Color | `white` |
+| Domain | Documentation quality |
+| Personality | Grumpy stickler - "Undocumented code is technical debt" |
+
+**Focus Areas:**
+- Missing or outdated documentation
+- Unclear README files
+- API documentation completeness
+- Code comments and inline docs
+- Example code accuracy
+- Changelog maintenance
+
+**Output Structure:**
+1. Documentation Summary
+2. Issues (missing, outdated, unclear)
+3. Required Updates
+4. Verdict
+
+### Agent 3: grumpy-testing-tyrant
+
+| Attribute | Value |
+|-----------|-------|
+| Name | grumpy-testing-tyrant |
+| Color | `brightBlue` |
+| Domain | Test coverage and quality |
+| Personality | Grumpy enforcer - "If it's not tested, it's not done" |
+
+**Focus Areas:**
+- Missing unit/integration/e2e tests
+- Inadequate assertions and edge cases
+- Flaky or brittle tests
+- Test isolation and independence
+- Mock/stub hygiene
+- Coverage gaps in critical paths
+
+**Output Structure:**
+1. Testing Summary
+2. Coverage Issues (gaps, weak assertions)
+3. Required Tests
+4. Verdict
+
+## Technical Approach
+
+### File Structure
+
+Each agent created as:
+```
+.claude/agents/parliament-of-chaos/grumpy-<name>.md
+```
+
+### Template Structure (32 lines target)
+
+```markdown
+---
+name: grumpy-<name>
+description: >-
+  <Two sentence description>
+model: inherit
+color: <color>
+---
+
+# Grumpy <Title>
+
+<One sentence personality/tone>
+
+## Focus Areas
+
+- <Area 1>
+- <Area 2>
+- <Area 3>
+
+## Process
+
+1. <Step 1>
+2. <Step 2>
+3. <Step 3>
+4. <Step 4>
+
+## Output
+
+1. **<Summary>** - <brief>
+2. **<Issues>** - <brief>
+3. **<Recommendations>** - <brief>
+4. **Verdict** - Approve/reject with reasoning
+```
+
+### Color Assignment Rationale
+
+| Agent | Color | Reason |
+|-------|-------|--------|
+| grumpy-accessibility-auditor | cyan | Associates with accessibility/inclusion, unused |
+| grumpy-documentation-pedant | white | Clean, paper-like, unused |
+| grumpy-testing-tyrant | brightBlue | Distinct from standards-enforcer blue, unused |
+
+**Colours already in use by grumpy reviewers:**
+- green (code-reviewer)
+- blue (standards-enforcer)
+- orange (architecture-skeptic)
+- yellow (maintainability-curmudgeon)
+- purple (security-nag)
+- red (performance-troll)
+
+## Integration Requirements
+
+### senior-council.md Update
+
+Add 3 new agents to Review Management responsibility:
+
+```
+grumpy-code-reviewer, grumpy-standards-enforcer, grumpy-architecture-skeptic,
+grumpy-maintainability-curmudgeon, grumpy-security-nag, grumpy-performance-troll,
+grumpy-accessibility-auditor, grumpy-documentation-pedant, grumpy-testing-tyrant
+```
+
+### README.md Updates
+
+1. Change "6 Grumpy Reviewers" to "9 Grumpy Reviewers"
+2. Add 3 new rows to Grumpy Reviewers table
+3. Update agent count if displayed elsewhere
+
+## Dependencies
+
+| Dependency | Status | Notes |
+|------------|--------|-------|
+| Phase 0 (token optimization) | Complete | Guidelines established |
+| Phase 1 (new specialists) | Complete | Pattern validated |
+| Existing grumpy reviewers | Complete | Template available |
+
+## Acceptance Criteria
+
+- [ ] All 3 agents created with correct YAML frontmatter
+- [ ] Each agent is 30-35 lines
+- [ ] Personality tone is grumpy/blunt
+- [ ] Output structure matches existing grumpy reviewer pattern
+- [ ] senior-council.md lists all 9 grumpy reviewers
+- [ ] README.md shows 9 grumpy reviewers with updated table
+- [ ] No color conflicts with existing agents
+
+## Edge Cases
+
+- **Overlap with ui-ux-guru**: accessibility-auditor focuses on compliance/violations; ui-ux-guru handles design patterns
+- **Overlap with doc-bard**: documentation-pedant reviews quality; doc-bard creates documentation
+- **Overlap with test-prophet**: testing-tyrant reviews coverage; test-prophet designs strategy
+
+## Notes
+
+- British spelling for consistency (optimisation, behaviour, colour references in docs)
+- All grumpy reviewers have 4-part output: Summary, Issues, Recommendations, Verdict
+- Agents critique but don't implement - they identify problems for specialists to fix

--- a/.project-files/roadmap/phase-2-grumpy-reviewers/tasks.md
+++ b/.project-files/roadmap/phase-2-grumpy-reviewers/tasks.md
@@ -1,0 +1,64 @@
+# Tasks: Phase 2 - New Grumpy Reviewers
+
+## Status: Complete
+
+## Overview
+
+Create 3 new grumpy reviewer agents, update senior-council and README.
+
+**Completed**: 2024-12-04
+**Dependencies**: None (Phase 0 and Phase 1 complete)
+
+---
+
+## Tasks
+
+### Agent Creation
+
+- [x] **Create grumpy-accessibility-auditor.md** (32 lines)
+  - Path: `.claude/agents/parliament-of-chaos/grumpy-accessibility-auditor.md`
+  - Color: cyan
+  - Focus: WCAG compliance, ARIA, keyboard nav, color contrast, screen readers
+
+- [x] **Create grumpy-documentation-pedant.md** (32 lines)
+  - Path: `.claude/agents/parliament-of-chaos/grumpy-documentation-pedant.md`
+  - Color: white
+  - Focus: Missing docs, outdated comments, unclear READMEs, API docs
+
+- [x] **Create grumpy-testing-tyrant.md** (32 lines)
+  - Path: `.claude/agents/parliament-of-chaos/grumpy-testing-tyrant.md`
+  - Color: brightBlue
+  - Focus: Coverage gaps, weak assertions, flaky tests, missing edge cases
+
+### Integration
+
+- [x] **Update senior-council.md grumpy reviewer list**
+  - Added: grumpy-accessibility-auditor, grumpy-documentation-pedant, grumpy-testing-tyrant
+  - Now lists 9 grumpy reviewers
+
+- [x] **Update README.md grumpy reviewer count**
+  - Changed "6 Grumpy Reviewers" to "9 Grumpy Reviewers"
+  - Changed "26 Agents" to "29 Agents"
+  - Added 3 new rows to Grumpy Reviewers table
+
+### Verification
+
+- [x] **Verify line counts**
+  - All 9 grumpy reviewers at exactly 32 lines
+
+- [x] **Verify structure consistency**
+  - Each agent has: YAML frontmatter, Focus Areas, Process, Output sections
+  - Output follows: Summary, Issues/Violations, Recommendations, Verdict pattern
+
+- [x] **Verify color uniqueness**
+  - cyan, white, brightBlue - all unique, no conflicts
+
+---
+
+## Definition of Done
+
+1. All 3 agent files created and line-count verified ✓
+2. senior-council.md lists 9 grumpy reviewers ✓
+3. README.md shows "9 Grumpy Reviewers" ✓
+4. README.md Grumpy Reviewers table has 9 rows ✓
+5. All colors are unique ✓

--- a/.project-files/roadmap/phase-2-grumpy-reviewers/work_complete.md
+++ b/.project-files/roadmap/phase-2-grumpy-reviewers/work_complete.md
@@ -1,0 +1,77 @@
+# Complete: Phase 2 - New Grumpy Reviewers
+
+**Completed**: 2024-12-04
+
+## Summary
+
+Created 3 new grumpy reviewer agents, expanding the review council from 6 to 9 reviewers. All agents follow the 32-line target and grumpy reviewer pattern.
+
+## Results
+
+| Metric | Value |
+|--------|-------|
+| Agents created | 3 |
+| Lines per agent | 32 |
+| Total grumpy reviewers | 9 |
+| Senior council updated | Yes |
+| README updated | Yes |
+
+### New Agents
+
+| Agent | Color | Domain | Lines |
+|-------|-------|--------|-------|
+| grumpy-accessibility-auditor | cyan | WCAG compliance, inclusive design | 32 |
+| grumpy-documentation-pedant | white | Documentation completeness, accuracy | 32 |
+| grumpy-testing-tyrant | brightBlue | Test coverage, quality | 32 |
+
+### Personality Lines
+
+- **accessibility-auditor**: "If it's not accessible, it's broken."
+- **documentation-pedant**: "Undocumented code is technical debt waiting to explode."
+- **testing-tyrant**: "If it's not tested, it doesn't work."
+
+## Tasks Done
+
+- [x] Create grumpy-accessibility-auditor.md
+- [x] Create grumpy-documentation-pedant.md
+- [x] Create grumpy-testing-tyrant.md
+- [x] Update senior-council.md grumpy reviewer list (6 → 9)
+- [x] Update README.md counts (26 → 29 agents, 6 → 9 reviewers)
+- [x] Verify line counts and structure
+
+## Files Changed
+
+### Created
+- `.claude/agents/parliament-of-chaos/grumpy-accessibility-auditor.md` (32 lines)
+- `.claude/agents/parliament-of-chaos/grumpy-documentation-pedant.md` (32 lines)
+- `.claude/agents/parliament-of-chaos/grumpy-testing-tyrant.md` (32 lines)
+
+### Modified
+- `.claude/agents/parliament-of-chaos/senior-council.md` - Added 3 new grumpy reviewers
+- `README.md` - Updated agent count (26→29), reviewer count (6→9), added table rows
+
+## Agents Consulted
+
+| Agent | Role |
+|-------|------|
+| senior-council | Orchestrated implementation |
+| task-executor | Safety checks, file creation |
+
+## Review Summary
+
+Grumpy review not required - configuration/documentation files following established template.
+
+## Decisions
+
+1. **Line count**: All agents at 32 lines, matching existing grumpy reviewers
+2. **Color selection**: cyan, white, brightBlue - all unique, visually distinct
+3. **Domain boundaries**:
+   - accessibility-auditor vs ui-ux-guru: Auditor finds violations; guru designs patterns
+   - documentation-pedant vs doc-bard: Pedant reviews; bard creates
+   - testing-tyrant vs test-prophet: Tyrant reviews coverage; prophet designs strategy
+
+## Notes for Future Work
+
+- cmd-parliament-review (Phase 3) is now unblocked - can use all 9 grumpy reviewers
+- Consider accessibility-auditor for all UI work, not just explicit a11y tasks
+- testing-tyrant should be consulted for any code changes, not just test files

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 
 Parliament of Chaos transforms Claude Code into a multi-agent development team. Instead of a single AI assistant, you get:
 
-- **26 Agents** including specialists, planners, reviewers, and an orchestrator
-- **6 Grumpy Reviewers** who find flaws others miss
+- **29 Agents** including specialists, planners, reviewers, and an orchestrator
+- **9 Grumpy Reviewers** who find flaws others miss
 - **7 Slash Commands** for project planning, scoping, implementation, and code review
 
 The result: thoroughly planned projects, battle-tested code, and solutions that have survived scrutiny from multiple perspectives.
@@ -94,7 +94,7 @@ The result: thoroughly planned projects, battle-tested code, and solutions that 
 | config-curator | Environment config, secrets, feature flags |
 | observability-oracle | Logging, metrics, tracing, alerting |
 
-### Grumpy Reviewers (6)
+### Grumpy Reviewers (9)
 
 | Agent | Focus |
 |-------|-------|
@@ -104,6 +104,9 @@ The result: thoroughly planned projects, battle-tested code, and solutions that 
 | grumpy-maintainability-curmudgeon | Long-term maintenance burden |
 | grumpy-security-nag | Security oversights |
 | grumpy-performance-troll | Performance issues |
+| grumpy-accessibility-auditor | WCAG compliance, inclusive design |
+| grumpy-documentation-pedant | Documentation completeness |
+| grumpy-testing-tyrant | Test coverage and quality |
 
 ### Orchestrator (1)
 


### PR DESCRIPTION
Introduces grumpy-accessibility-auditor, grumpy-documentation-pedant, and grumpy-testing-tyrant agents, expanding the grumpy reviewer council from 6 to 9. Updates senior-council.md and README.md to reflect the new agents and reviewer count, and adds roadmap documentation for phase 2 completion.